### PR TITLE
Update Dockerfile for container to be stand-alone.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-FROM node:6.13.1
+FROM node:6-alpine
 
+RUN apk update; apk add ncurses make bash
+
+ADD ./package.json /app/package.json
 WORKDIR /app
+
+RUN npm install
+
+ADD . /app
 
 EXPOSE 5000

--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -1,7 +1,2 @@
 #!/bin/bash
-
-npm cache clean
-
-npm install
-
 node server.js


### PR DESCRIPTION
The old image did not contain the source file and did not run docker-prepare-sh by itself,
making it difficult to create deployments automatically, especially with Kubernetes.