### PR TITLE
server.js: Use redis to register clients instead of postgres [Don't Merge, WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "sequelize": "4.39.0",
     "pg-hstore": "2.3.2",
     "pg": "7.5.0",
-    "kafka-node": "^3.0.1"
+    "kafka-node": "^3.0.1",
+    "redis": "2.8.0"
   },
   "author": "Intel, CPG",
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -161,7 +161,7 @@ wsServer.on('request', function(request) {
         connection.on('close', function(reasonCode, description) {
             Object.keys(clients).some(function(deviceId) {
                 if(clients[deviceId] === connection) {
-		    redisClient.del('dummyvalue', function(err, response) {
+		    redisClient.del(devideId, function(err, response) {
 			if (response == 1) {
 			    console.log("Removed " + deviceId + "from Redis upon disconnect.");
 			} else{


### PR DESCRIPTION
 See #22. Initial implementation.

This is work in progress. The corresponding PR from Frontend is on its way by @oguzcankirmemis . 

Creating the PR as reference for MQTT.