### PR TITLE
Fix hostname

### DIFF
--- a/config.js
+++ b/config.js
@@ -140,13 +140,8 @@ var config = {
     }
 };
 
-if (process.env.DASHBOARD_SERVICE_HOST) {
-    config.ws.externalAddress = config.ws.serverAddress + '.websocket-server';
-} else {
-    config.ws.externalAddress = config.ws.serverAddress;
-}
 config.ws.externalPort = config.ws.port;
-
+config.ws.externalAddress = config.ws.serverAddress + '.websocket-server';
 
 
 module.exports = config;


### PR DESCRIPTION
Hostname was used to be derived differently for docker and k8s. Docker support dropped in favour of fleixiblity in other service names.

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>