### PR TITLE
Bugfix: The websocket server is registering for every device the 'acc…

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,7 +94,8 @@ var config = {
         	        winston.format.timestamp(),
         	        winston.format.printf(info => { return `${info.timestamp}-${info.level}: ${info.message}`; })
         	     ),
-        transports : [new winston.transports.Console()]
+        transports : [new winston.transports.Console()],
+        level: process.env.DEBUG || "info"
     }
 };
 

--- a/iot-entities/redis/client.js
+++ b/iot-entities/redis/client.js
@@ -70,6 +70,11 @@ function RedisClient(conf) {
         }
     };
 
+    me.unsubscribe = function(channel) {
+
+        me.client.unsubscribe(channel);
+    };
+
     me.onMessage = function(callback) {
         if ( callback ) {
             me.client.on('message', function (channel, message) {

--- a/lib/logger/winstonLogger.js
+++ b/lib/logger/winstonLogger.js
@@ -20,5 +20,6 @@ var winston = require('winston'),
 
 module.exports = winston.createLogger({
     format: loggerConf.format,
-    transports: loggerConf.transports
+    transports: loggerConf.transports,
+    level: loggerConf.level
 });


### PR DESCRIPTION
…ountId/deviceId' channel at redis.

Unfortunatley, Redis is sending all broadcast to all instances. So if for instance two devices are registered, both routines get the request to send the command. This leads to duplications
of command messages. This patch adds filtering to avoid duplication of several messages and only the addressed subroutine is answering.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>